### PR TITLE
Add  find routes list function

### DIFF
--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -3,7 +3,21 @@ import { Routes, Route, Outlet, Link } from "react-router-dom";
 
 export default function App() {
   return (
-    
+    <div>
+      <h1>Basic Example</h1>
+
+      <p>
+        This example demonstrates some of the core features of React Router
+        including nested <code>&lt;Route&gt;</code>s,{" "}
+        <code>&lt;Outlet&gt;</code>s, <code>&lt;Link&gt;</code>s, and using a
+        "*" route (aka "splat route") to render a "not found" page when someone
+        visits an unrecognized URL.
+      </p>
+
+      {/* Routes nest inside one another. Nested route paths build upon
+            parent route paths, and nested route elements render inside
+            parent route elements. See the note about <Outlet> below. */}
+      <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
           <Route path="about" element={<About />} />
@@ -14,6 +28,8 @@ export default function App() {
                 routes for. */}
           <Route path="*" element={<NoMatch />} />
         </Route>
+      </Routes>
+    </div>
   );
 }
 

--- a/src/implementations.ts
+++ b/src/implementations.ts
@@ -1,10 +1,8 @@
 import {createRoutesFromChildren} from 'react-router'
-import {getRouteList} from './reactRoutes';
+import {getRouteList, findRoutesList} from './reactRoutes';
 import App from '../examples/basic/src/App';
-function findRoutesList(el) {
-  console.log(el.props.children[2].type.name === 'Routes')
-}
-// const list = getRouteList(createRoutesFromChildren(App.default()), "");
+
 // @ts-ignore
-const list = findRoutesList(App.default())
-// console.log(list);
+const routesList = findRoutesList(App.default())
+const list = getRouteList(createRoutesFromChildren(routesList.props.children), "");
+console.log(list);

--- a/src/implementations.ts
+++ b/src/implementations.ts
@@ -1,5 +1,10 @@
 import {createRoutesFromChildren} from 'react-router'
 import {getRouteList} from './reactRoutes';
 import App from '../examples/basic/src/App';
-const list = getRouteList(createRoutesFromChildren(App.default()), "");
-console.log(list);
+function findRoutesList(el) {
+  console.log(el.props.children[2].type.name === 'Routes')
+}
+// const list = getRouteList(createRoutesFromChildren(App.default()), "");
+// @ts-ignore
+const list = findRoutesList(App.default())
+// console.log(list);

--- a/src/reactRoutes.ts
+++ b/src/reactRoutes.ts
@@ -1,12 +1,21 @@
+import React from 'react'
 import {Children, isValidElement, ReactNode, Fragment} from "react";
 import { Route } from "react-router-dom";
 function invariant(cond: any, message: any) {
   if (!cond) throw new Error(message);
 }
-interface ResolvedRoute {
-  path: string;
-  children: ResolvedRoute[];
-  props: {children: ResolvedRoute[]};
+
+export function findRoutesList(el) {
+  // Exit condition
+  if(el.type?.name === 'Routes') {return el}
+  // If has children
+  if(el.props?.children) {
+    const childrenLength = el.props.children.length
+    for(let i = 0; i < childrenLength; i++) {
+      // If recursion ever passes shortcircuit early.
+      if(findRoutesList(el.props.children[i])) { return el.props.children[i] }
+    }
+  }
 }
 
 export const getRouteList = (routes: any, appBasePath: string) => {
@@ -20,6 +29,12 @@ export const getRouteList = (routes: any, appBasePath: string) => {
     .filter((x: string) => x !== "" && x !== "/")
     .map((x: string) => `${appBasePath}/` + x);
 };
+
+interface ResolvedRoute {
+  path: string;
+  children: ResolvedRoute[];
+  props: {children: ResolvedRoute[]};
+}
 
 function buildRoutePath(
   routes: ResolvedRoute[],


### PR DESCRIPTION
This change adds the following updates:
1. Adds a find routes list function. 

Now an entire react app can be passed to the command line. Meaning no special exports need to be setup. 🎉
This should work with most examples in the example repo.

The work left is adding some finishing touches:
1. to handle some syntax adjustments
2. correct any missing paths in the main path building buildRoutePath function.

<img width="1506" alt="it_works" src="https://github.com/user-attachments/assets/d47cb070-02be-4ba2-838a-d18464dab543">
